### PR TITLE
Feature/exclute option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This command outputs the contents of specified files in Markdown code block form
 - Outputs the contents of specified files in Markdown code block format.
 - Allows users to choose between relative or absolute paths for the output.
 - Provides warnings for non-existent files, directories, or symbolic links.
+- Excludes the paths from the Output files with command line option.
 
 ---
 
@@ -22,6 +23,7 @@ This command outputs the contents of specified files in Markdown code block form
 ### Options
 
 - `-a`, `--absolute`: Display absolute paths in the output (default is relative paths).
+- `-e`, `--exclude` `<EXCLUDE>`: Exclude the paths from the outputs.
 
 ### Arguments
 
@@ -71,6 +73,13 @@ fn main() {
 You can specify multiple files to process them sequentially:
 
 `cbcopy src/main.rs src/lib.rs`
+
+
+### Exclude paths from outputs
+
+You can select excluded paths not to copy specific files:
+
+`cbcopy src/main.rs -e src/lib.rs`
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,11 +60,15 @@ fn main() {
     let mut printed_files = Vec::new();
     let mut excluded_files = Vec::new();
     for file_name in &file_names {
+        let path = Path::new(&file_name);
         if !exclude_patterns.is_empty() && exclude_patterns.iter().any(|pattern| file_name.contains(pattern)) {
-            excluded_files.push(file_name);
+            let path_to_display = match is_absolute {
+                true => get_absolute_path(&path),
+                false => get_relative_path(&path),
+            };
+            excluded_files.push(path_to_display.clone());
             continue;
         }
-        let path = Path::new(&file_name);
 
         if path.is_file() {
             found_any_file = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::{env, fs::File, io::prelude::*, path::Path};
+use std::{env, fs::File, io::{self, prelude::*}, path::{Path, PathBuf}};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -13,76 +13,74 @@ struct Args {
     exclude: Vec<String>,
 }
 
-fn read_file(path: &Path) -> String {
-    let mut f = File::open(path).expect("File not found");
+fn resolve_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
 
+fn resolve_exclude_pattern(pattern: &str) -> PathBuf {
+    let p = Path::new(pattern);
+    p.canonicalize().unwrap_or_else(|_| {
+        let current_dir = env::current_dir().unwrap();
+        current_dir.join(p)
+    })
+}
+
+fn read_file(path: &Path) -> io::Result<String> {
+    let mut f = File::open(path)?;
     let mut contents = String::new();
-    f.read_to_string(&mut contents)
-        .expect("Failed to read file");
-    contents
+    f.read_to_string(&mut contents)?;
+    Ok(contents)
 }
 
-fn get_relative_path(path: &Path) -> std::io::Result<String> {
-    let absolute_path = path
-        .canonicalize()?;
-    let current_dir = env::current_dir()?;
-    Ok(absolute_path
+fn get_relative_path(canonical: &Path) -> PathBuf {
+    let current_dir = env::current_dir().unwrap();
+    canonical
         .strip_prefix(&current_dir)
-        .unwrap_or(&absolute_path)
-        .to_string_lossy()
-        .to_string())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| canonical.to_path_buf())
 }
 
-fn get_absolute_path(path: &Path) -> std::io::Result<String> {
-    Ok(path.canonicalize()?.to_string_lossy().to_string())
-}
-
-fn print_code(path: &str, code: String) {
+fn print_code(path: &Path, code: &str) {
     println!("```");
-    println!("// {}", path);
+    println!("// {}", path.display());
     print!("{}", code);
     println!("```");
     println!();
 }
 
-fn main() -> std::io::Result<()> {
+fn main() -> io::Result<()> {
     let args = Args::parse();
 
     let is_absolute = args.absolute;
-    let exclude_patterns = args.exclude;
+    let exclude_patterns: Vec<PathBuf> = args.exclude.iter().map(|p| resolve_exclude_pattern(p)).collect();
     let mut found_any_file = false;
     let file_names = args.file_paths;
 
     let mut printed_files = Vec::new();
     let mut excluded_files = Vec::new();
     for file_name in &file_names {
-        let path = Path::new(&file_name);
-
-        let abs_path_str = match get_absolute_path(&path) {
-            Ok(s) => s,
-            Err(_) => file_name.to_string(),
+        let path = Path::new(file_name);
+        let canonical = resolve_path(path);
+        let display_path = if is_absolute {
+            canonical.clone()
+        } else {
+            get_relative_path(&canonical)
         };
 
-        if !exclude_patterns.is_empty() && exclude_patterns.iter().any(|pattern| abs_path_str.contains(pattern)) {
-            let path_to_display = if is_absolute {
-                get_absolute_path(&path)?
-            } else {
-                get_relative_path(&path)?
-            };
-            excluded_files.push(path_to_display.clone());
+        if !exclude_patterns.is_empty()
+            && exclude_patterns
+                .iter()
+                .any(|pat| canonical.to_string_lossy().contains(&*pat.to_string_lossy()))
+        {
+            excluded_files.push(display_path);
             continue;
         }
 
         if path.is_file() {
             found_any_file = true;
-            let path_to_display = if is_absolute {
-                get_absolute_path(&path)?
-            } else {
-                get_relative_path(&path)?
-            };
-            printed_files.push(path_to_display.clone());
-            let code = read_file(&path);
-            print_code(&path_to_display, code);
+            printed_files.push(display_path.clone());
+            let code = read_file(&canonical)?;
+            print_code(&display_path, &code);
         } else if path.is_dir() {
             eprintln!("Warning: {} is a directory", file_name);
         } else if path.is_symlink() {
@@ -96,7 +94,7 @@ fn main() -> std::io::Result<()> {
     if !excluded_files.is_empty() {
         eprintln!("Excluded files:");
         for excluded_file in excluded_files {
-            eprintln!("{}", excluded_file);
+            eprintln!("{}", excluded_file.display());
         }
     }
 
@@ -105,7 +103,7 @@ fn main() -> std::io::Result<()> {
     } else {
         eprintln!("Printed files:");
         for printed_file in printed_files {
-            eprintln!("{}", printed_file);
+            eprintln!("{}", printed_file.display());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ struct Args {
 
     #[arg(short, long, default_value = "false")]
     absolute: bool,
+
+    #[arg(short, long)]
+    exclude: Vec<String>,
 }
 
 fn read_file(path: &Path) -> String {
@@ -50,11 +53,17 @@ fn main() {
     let args = Args::parse();
 
     let is_absolute = args.absolute;
+    let exclude_patterns = args.exclude;
     let mut found_any_file = false;
     let file_names = args.file_paths;
 
     let mut printed_files = Vec::new();
+    let mut excluded_files = Vec::new();
     for file_name in &file_names {
+        if !exclude_patterns.is_empty() && exclude_patterns.iter().any(|pattern| file_name.contains(pattern)) {
+            excluded_files.push(file_name);
+            continue;
+        }
         let path = Path::new(&file_name);
 
         if path.is_file() {
@@ -74,6 +83,12 @@ fn main() {
             eprintln!("Warning: {} is not a file", file_name);
         } else {
             eprintln!("Warning: {} does not exist", file_name);
+        }
+    }
+    if !excluded_files.is_empty() {
+        eprintln!("Excluded files:");
+        for excluded_file in excluded_files {
+            eprintln!("{}", excluded_file);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 use clap::Parser;
-use std::{env, fs::File, io::{self, prelude::*}, path::{Path, PathBuf}};
+use std::{
+    env,
+    fs::File,
+    io::{self, prelude::*},
+    path::{Path, PathBuf},
+};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -52,7 +57,11 @@ fn main() -> io::Result<()> {
     let args = Args::parse();
 
     let is_absolute = args.absolute;
-    let exclude_patterns: Vec<PathBuf> = args.exclude.iter().map(|p| resolve_exclude_pattern(p)).collect();
+    let exclude_patterns: Vec<PathBuf> = args
+        .exclude
+        .iter()
+        .map(|p| resolve_exclude_pattern(p))
+        .collect();
     let mut found_any_file = false;
     let file_names = args.file_paths;
 
@@ -68,9 +77,11 @@ fn main() -> io::Result<()> {
         };
 
         if !exclude_patterns.is_empty()
-            && exclude_patterns
-                .iter()
-                .any(|pat| canonical.to_string_lossy().contains(&*pat.to_string_lossy()))
+            && exclude_patterns.iter().any(|pat| {
+                canonical
+                    .to_string_lossy()
+                    .contains(&*pat.to_string_lossy())
+            })
         {
             excluded_files.push(display_path);
             continue;


### PR DESCRIPTION
# Feature
- Exclude option
## Example
```bash
$ cbcopy **/*.ts -e node_modules | pbcopy
Excluded files:
node_modules/**/*.ts
Printed files:
**/*.ts
```
## Help
```bash
$ cbcopy --help                          
Usage: cbcopy [OPTIONS] [FILE_PATHS]...

Arguments:
  [FILE_PATHS]...  

Options:
  -a, --absolute           
  -e, --exclude <EXCLUDE>  
  -h, --help               Print help
  -V, --version            Print version
```